### PR TITLE
Add splunk logging

### DIFF
--- a/besu/build.gradle
+++ b/besu/build.gradle
@@ -65,6 +65,7 @@ dependencies {
   implementation 'org.springframework.security:spring-security-crypto'
 
   runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
+  runtimeOnly 'com.splunk.logging:splunk-library-javalogging'
 
   testImplementation project(path: ':ethereum:core', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':crypto', configuration: 'testSupportArtifacts')

--- a/besu/src/main/resources/log4j2.xml
+++ b/besu/src/main/resources/log4j2.xml
@@ -1,16 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="INFO">
   <Properties>
-    <Property name="root.log.level">INFO</Property>
+    <Property name="root.log.level">${env:LOG_LEVEL:-INFO}</Property>
+    <Property name="root.log.logger">${env:LOGGER:-Console}</Property>
+    <Property name="host">${env:HOST:-${docker:containerId:-localhost}}</Property>
+    <Property name="splunk.url">${env:SPLUNK_URL}</Property>
+    <Property name="splunk.token">${env:SPLUNK_TOKEN}</Property>
+    <Property name="splunk.index">${env:SPLUNK_INDEX}</Property>
+    <Property name="splunk.source">${env:SPLUNK_SOURCE:-besu}</Property>
+    <Property name="splunk.sourcetype">${env:SPLUNK_SOURCETYPE:-besu}</Property>
+    <Property name="splunk.batch_size_bytes">${env:SPLUNK_BATCH_SIZE_BYTES:-65536}</Property>
+    <Property name="splunk.batch_size_count">${env:SPLUNK_BATCH_SIZE_COUNT:-1000}</Property>
+    <Property name="splunk.batch_interval">${env:SPLUNK_BATCH_INTERVAL:-500}</Property>
+    <Property name="splunk.disableCertificateValidation">${env:SPLUNK_SKIPTLSVERIFY:-false}</Property>
   </Properties>
 
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSSZZZ} | %t | %-5level | %c{1} | %msg%n" />    </Console>
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSSZZZ} | %t | %-5level | %c{1} | %msg%n" />
+    </Console>
+
+    <SplunkHttp name="Splunk"
+                url="${sys:splunk.url}"
+                token="${sys:splunk.token}"
+                host="${sys:host}"
+                index="${sys:splunk.index}"
+                source="${sys:splunk.source}"
+                sourcetype="${sys:splunk.sourcetype}"
+                messageFormat="text"
+                batch_size_bytes="${sys:splunk.batch_size_bytes}"
+                batch_size_count="${sys:splunk.batch_size_count}"
+                batch_interval="${sys:splunk.batch_interval}"
+                disableCertificateValidation="${sys:splunk.disableCertificateValidation}">
+      <PatternLayout pattern="%msg"/>
+    </SplunkHttp>
+
+    <Routing name="Router">
+      <Routes pattern="$${sys:root.log.logger}">
+        <Route ref="Console" key="Console" />
+        <Route ref="Splunk" key="Splunk" />
+      </Routes>
+    </Routing>
   </Appenders>
   <Loggers>
     <Root level="${sys:root.log.level}">
-      <AppenderRef ref="Console" />
+      <AppenderRef ref="Router" />
     </Root>
   </Loggers>
 </Configuration>

--- a/build.gradle
+++ b/build.gradle
@@ -124,7 +124,7 @@ allprojects {
     mavenCentral()
     mavenLocal()
     maven { url "https://consensys.bintray.com/pegasys-repo" }
-    maven { url "https://repository.apache.org/content/repositories/snapshots/" }
+    maven { url "https://repo.spring.io/libs-release" }
   }
 
   dependencies { errorprone "com.google.errorprone:error_prone_core" }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -30,6 +30,8 @@ dependencyManagement {
 
     dependency 'com.graphql-java:graphql-java:13.0'
 
+    dependency 'com.splunk.logging:splunk-library-javalogging:1.8.0'
+
     dependency 'com.squareup.okhttp3:okhttp:4.2.2'
 
     dependency 'commons-cli:commons-cli:1.4'


### PR DESCRIPTION
This adds splunk logging to Besu.

Splunk logging is added as a runtime jar that is pulled from the Spring releases Maven repository.
This PR also removes the Maven repository for the ASF snapshots repository, as no dependencies use this repository at this time.

This change allows users to define Splunk as logger using system properties or environment variables.
This also allows users to change the log level using environment variables if they so choose.

To configure Splunk, you may set the following environment variables:

| Name             | Description    | Required       |
| ------------- | ------------- |------------- |
| LOGGER | Must be set to `Splunk` to activate Splunk logging | Yes |
| HOST | Current host. If in a Docker environment, the default value is the docker container ID. Otherwise the default value is `localhost`. | No |
| SPLUNK_URL | URL to the Splunk instance, for example https://localhost:8088 | Yes |
| SPLUNK_TOKEN | Authentication token, usually of the form 11111111-1111-1111-1111-111111111111 | Yes |
| SPLUNK_INDEX | [Index](https://docs.splunk.com/Splexicon:Index) in which logs will be stored. Defaults to `besu` | Yes |
| SPLUNK_SOURCE | [Source of the logs](https://docs.splunk.com/Splexicon:Source). This may be overridden by the Splunk HTTP Event Collector. Defaults to `besu` | No |
| SPLUNK_SOURCETYPE | [Sourcetype of the logs](https://docs.splunk.com/Splexicon:Sourcetype). This may be overridden by the Splunk HTTP Event Collector. Defaults to `besu` | No |
| SPLUNK_BATCH_SIZE_BYTES | Size of a batch in bytes. Defaults to `65536` | No |
| SPLUNK_BATCH_SIZE_COUNT | Size of a batch in number of events. Defaults to `1000` | No |
| SPLUNK_BATCH_INTERVAL | Interval at which to send batches. Defaults to `500` | No |
| SPLUNK_SKIPTLSVERIFY | Whether to check the Splunk instance certificate when sending data. Defaults to `true` | No |

![Screen Shot 2020-04-14 at 3 45 45 PM](https://user-images.githubusercontent.com/16758/79282017-f0362400-7e68-11ea-8f81-9d025dd01766.png)
